### PR TITLE
add send 500 error -- server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,14 @@ const pool = new Pool({
   ssl: { rejectUnauthorized: false }, // SSL
 });
 
+pool.on('error', (err, client) => {
+  console.error('Unexpected error on idle client', err);
+});
+
+app.use((err, req, res, next) => {
+  console.error('Database error:', err);
+  res.status(500).json({ error: 'Internal Server Error' });
+});
 
 // Middleware
 app.use(express.json());


### PR DESCRIPTION
This code sends a 500 error on error connecting to a database, this helps uptime tools decide if the app is fully functioning.

Use case: If there is a incorrect, malformed, or missing postgreSQL URL but the website is still up any normal uptime tool will mark the project as stable. Not anymore